### PR TITLE
removes port variable from start script - windows env issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ While no previous background is required to complete this task or to apply to th
 5. Install the project dependencies by running `npm install` from the project's directory (using a terminal)
 6. Run the project by running `npm start`
 
-You should now have the development version running on your computer and accessible via http://localhost:3001
+You should now have the development version running on your computer and accessible via http://localhost:3000
 
 ## Tasks
 

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "typescript": "3.5.3"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
@GabiGrin This caused issues on Windows since there is no bash...
We can add an `env` file to keep this but the easy fix is to just remove it for now